### PR TITLE
fix: move default export to the end

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "source": "src/index.ts",
   "exports": {
     "require": "./dist/queueable.js",
-    "default": "./dist/queueable.modern.mjs",
-    "types": "./dist/index.d.ts"
+    "types": "./dist/index.d.ts",
+    "default": "./dist/queueable.modern.mjs"
   },
   "types": "./dist/index.d.ts",
   "main": "./dist/queueable.js",


### PR DESCRIPTION
This moves the default export to the end of the export section. This avoids build errors with webpack. This resolves `Default condition should be last one` errors.

Other libraries also have similar issues, just copied the trick from over there: https://github.com/vuejs/vue-test-utils/pull/2023